### PR TITLE
Added support for SSL via connection string

### DIFF
--- a/src/NServiceBus.Transports.WebSphereMQ/Config/WebSphereMQTransport.cs
+++ b/src/NServiceBus.Transports.WebSphereMQ/Config/WebSphereMQTransport.cs
@@ -4,6 +4,7 @@
     using Senders;
     using Settings;
     using WebSphereMQ = NServiceBus.WebSphereMQ;
+    using System;
 
     public class WebSphereMQTransport : ConfigureTransport<WebSphereMQ>
     {
@@ -15,6 +16,8 @@
         public override void Initialize()
         {
             Address.IgnoreMachineName();
+
+            Environment.SetEnvironmentVariable("AMQ_SSL_ALLOW_DEFAULT_CERT", "true");
 
             var connectionString = SettingsHolder.Get<string>("NServiceBus.Transport.ConnectionString");
             var parser = new ConnectionStringBuilder(connectionString);

--- a/src/NServiceBus.Transports.WebSphereMQ/ConnectionFactory.cs
+++ b/src/NServiceBus.Transports.WebSphereMQ/ConnectionFactory.cs
@@ -24,8 +24,11 @@
             connectionFactory.SetStringProperty(XMSC.WMQ_HOST_NAME, settings.Hostname);
             connectionFactory.SetIntProperty(XMSC.WMQ_PORT, settings.Port);
             connectionFactory.SetStringProperty(XMSC.WMQ_CHANNEL, settings.Channel);
-            connectionFactory.SetIntProperty(XMSC.WMQ_CONNECTION_MODE, XMSC.WMQ_CM_CLIENT);
+            connectionFactory.SetIntProperty(XMSC.WMQ_CONNECTION_MODE, XMSC.WMQ_CM_CLIENT_UNMANAGED);
             connectionFactory.SetStringProperty(XMSC.WMQ_QUEUE_MANAGER, settings.QueueManager);
+            connectionFactory.SetStringProperty(XMSC.WMQ_SSL_CIPHER_SPEC, settings.SslCipherSpec);
+            connectionFactory.SetStringProperty(XMSC.WMQ_SSL_KEY_REPOSITORY, settings.SslKeyRepository);
+            connectionFactory.SetStringProperty(XMSC.WMQ_SSL_PEER_NAME, settings.SslPeerName);
         }
 
         ~ConnectionFactory()

--- a/src/NServiceBus.Transports.WebSphereMQ/ConnectionStringBuilder.cs
+++ b/src/NServiceBus.Transports.WebSphereMQ/ConnectionStringBuilder.cs
@@ -28,6 +28,14 @@
             if (ContainsKey("maxQueueDepth"))
                 settings.MaxQueueDepth = (int)this["maxQueueDepth"];
 
+            if (ContainsKey("sslCipherSpec"))
+                settings.SslCipherSpec = (string)this["sslCipherSpec"];
+
+            if (ContainsKey("sslKeyRepository"))
+                settings.SslKeyRepository = (string)this["sslKeyRepository"];
+
+            if (ContainsKey("sslPeerName"))
+                settings.SslPeerName = (string)this["sslPeerName"];
 
             return settings;
         }

--- a/src/NServiceBus.Transports.WebSphereMQ/QueueCreator.cs
+++ b/src/NServiceBus.Transports.WebSphereMQ/QueueCreator.cs
@@ -21,8 +21,11 @@
                 {
                     {MQC.HOST_NAME_PROPERTY, Settings.Hostname},
                     {MQC.PORT_PROPERTY, Settings.Port},
-                    {MQC.TRANSPORT_PROPERTY, MQC.TRANSPORT_MQSERIES_MANAGED},
-                    {MQC.CHANNEL_PROPERTY, Settings.Channel}
+                    {MQC.TRANSPORT_PROPERTY, MQC.TRANSPORT_MQSERIES},
+                    {MQC.CHANNEL_PROPERTY, Settings.Channel},
+                    {MQC.SSL_CIPHER_SPEC_PROPERTY, Settings.SslCipherSpec},
+                    {MQC.SSL_CERT_STORE_PROPERTY, Settings.SslKeyRepository},
+                    {MQC.SSL_PEER_NAME_PROPERTY, Settings.SslPeerName}
                 };
 
             using (var queueManager = new MQQueueManager(Settings.QueueManager, properties))

--- a/src/NServiceBus.Transports.WebSphereMQ/WebSphereMqSettings.cs
+++ b/src/NServiceBus.Transports.WebSphereMQ/WebSphereMqSettings.cs
@@ -22,5 +22,11 @@
         public int Port { get; set; }
 
         public string Hostname { get; set; }
+
+        public string SslCipherSpec { get; set; }
+
+        public string SslKeyRepository { get; set; }
+
+        public string SslPeerName { get; set; }
     }
 }


### PR DESCRIPTION
The usage is 3 new optional parameters for a connection string:
1. `sslCipherSpec`: the algorithms used
2. `sslKeyRepository`: the location of the certificate repository (CMS type, kdb is the file extension, the path should not contain the file extension)
3. `sslPeerName`: the expected subject of the server certificate

Example usage:
`sslCipherSpec=NULL_SHA;sslKeyRepository=../../keyrepository;sslPeerName=CN=MQSERVER`

Is there a place to add documentation for that?

Implementation:
I initialized the environment variable `AMQ_SSL_ALLOW_DEFAULT_CERT` to true in order for the infrastructure to select the default client certificate from the certificate repository, otherwise it searches for certificate with the name webspheremq[current-windows-username] which is more brittle.

I had to change the transport to unmanaged to support SSL, I didn't see any implications for that.

I didn't add tests because the settings and connection creation parts weren't covered anyway and those were the only files I touched.
